### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,11 @@ homepage = "https://github.com/solokeys/ctap-types"
 [dependencies]
 bitflags = "1.3"
 cbor-smol = "0.4"
-cosey = "0.3"
 delog = "0.1"
 heapless = { version = "0.7", default-features = false, features = ["serde"] }
 heapless-bytes = "0.3"
-interchange = "0.2.1"
 iso7816 = "0.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde-byte-array = "0.1.2"
 serde-indexed = "0.1"
 serde_bytes = { version = "0.11.12", default-features = false }
 serde_repr = "0.1"


### PR DESCRIPTION
These dependencies are not used (anymore?), some of them caused duplicates in the final firmware.